### PR TITLE
Add linting, tests and Dagger workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  dagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dagger/dagger-for-github@v5
+        with:
+          cmds: lint,test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.6
+    hooks:
+      - id: ruff

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -1,0 +1,1 @@
+module: "github.com/minimaldevops/md-github-traffic"

--- a/github_traffic_tracker.py
+++ b/github_traffic_tracker.py
@@ -4,7 +4,6 @@ from dotenv import load_dotenv
 import requests
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
-from datetime import datetime
 import yaml
 
 # Load environment variables

--- a/main.cue
+++ b/main.cue
@@ -1,0 +1,34 @@
+package dagger
+
+import (
+    "dagger.io/dagger"
+)
+
+#base: dagger.#Container & {
+    from: "python:3.11-slim"
+    workdir: "/src"
+    withMountedDirectory: "/src": dagger.#FS {
+        source: dagger.#Local{
+            path: "./"
+        }
+    }
+}
+
+lint: #base & {
+    withExec: [
+        "pip", "install", "-r", "requirements-dev.txt"
+    ]
+    withExec: ["ruff", "."]
+}
+
+test: #base & {
+    withExec: [
+        "pip", "install", "-r", "requirements-dev.txt"
+    ]
+    withExec: ["pytest"]
+}
+
+dagger.#Plan & {
+    pipeline lint: lint
+    pipeline test: test
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+line-length = 120
+
+[tool.pytest.ini_options]
+addopts = "-vv"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+ruff
+pre-commit

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,66 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import github_traffic_tracker as tracker
+
+
+def test_load_repositories(tmp_path, monkeypatch):
+    yaml_content = """\
+repos:
+  - owner: foo
+    repo: bar
+  - owner: baz
+    repo: qux
+"""
+    yaml_file = tmp_path / "repos.yaml"
+    yaml_file.write_text(yaml_content)
+    monkeypatch.chdir(tmp_path)
+    repos = tracker.load_repositories()
+    assert repos == [("foo", "bar"), ("baz", "qux")]
+
+
+def test_fetch_github_traffic(monkeypatch):
+    class MockResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+        def raise_for_status(self):
+            pass
+
+    def mock_get(url, headers):
+        if url.endswith("/views"):
+            return MockResponse({"views": [{"timestamp": "2024-06-01T00:00:00Z", "count": 1, "uniques": 1}]})
+        return MockResponse({"clones": [{"timestamp": "2024-06-01T00:00:00Z", "count": 2, "uniques": 2}]})
+
+    monkeypatch.setattr(tracker.requests, "get", mock_get)
+    views, clones = tracker.fetch_github_traffic("foo", "bar", "token")
+    assert views[0]["count"] == 1
+    assert clones[0]["count"] == 2
+
+
+def test_upsert_traffic_metric(monkeypatch):
+    executed = {}
+
+    class MockConn:
+        def execute(self, sql, params):
+            executed.update(params)
+
+        def commit(self):
+            executed["committed"] = True
+
+    conn = MockConn()
+    tracker.upsert_traffic_metric(conn, "foo/bar", "2024-06-01", 1, 1, 2, 2)
+    assert executed["repo_name"] == "foo/bar"
+    assert executed["committed"] is True
+
+
+def test_main_missing_token(monkeypatch, caplog):
+    monkeypatch.setattr(tracker, "GITHUB_TOKEN", None)
+    caplog.set_level("ERROR")
+    tracker.main()
+    assert any("GITHUB_TOKEN not set" in m for m in caplog.messages)


### PR DESCRIPTION
## Summary
- add unit tests
- configure Ruff linter
- add pre-commit config
- declare dev requirements
- add Dagger CUE pipeline and CI workflow

## Testing
- `ruff check github_traffic_tracker.py tests/test_tracker.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails due to network)*
- `pre-commit run --files github_traffic_tracker.py tests/test_tracker.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854598e50e0832690e9a60251efa516