### PR TITLE
Update CI to run Dagger tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,5 @@ jobs:
       - name: Install Dagger
         run: curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.18.10 BIN_DIR=/usr/local/bin sh
 
-      - uses: dagger/dagger-for-github@v5
-        with:
-          cmds: lint,test
+      - name: Run Dagger tests
+        run: dagger do lint test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,8 @@ jobs:
       - name: Install Dagger
         run: curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.18.10 BIN_DIR=/usr/local/bin sh
 
+      - name: Run Dagger lint
+        run: dagger call --module . lint
+
       - name: Run Dagger tests
-        run: dagger do lint test
+        run: dagger call --module . test


### PR DESCRIPTION
## Summary
- run Dagger tests directly on the self-hosted runner

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_68546a51a2788326b4ad759d02a2b642